### PR TITLE
feat: frontend now accepts full github urls as input

### DIFF
--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -36,7 +36,12 @@ h1 {
     align-items: center;
 }
 
-#gituser, #repository, .submit-button {
+.submit-button {
+    grid-column: span 4;
+    padding: 10px;
+}
+
+#giturl {
     grid-column: span 4;
     padding: 10px;
 }
@@ -80,6 +85,7 @@ h1 {
     position: relative;
     width: 100%;
     min-width: 50px;
+
 }
 
 .reset-icon {

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -18,8 +18,7 @@
     <div class="container">
         <div class="input-area">
             <form id="repoForm" class="form">
-                <input type="text" id="gituser" placeholder="Enter GitHub Username">
-                <input type="text" id="repository" placeholder="Enter Repository Name">
+                <input type="text" id="giturl" placeholder="Enter GitHub Repository URL">
 
                 <label for="bg_color">BG</label>
                 <div class="color-container">

--- a/src/static/js/script.js
+++ b/src/static/js/script.js
@@ -3,15 +3,30 @@ const googleAnalyticsID = window.config.googleAnalyticsID;
 document.getElementById('repoForm').addEventListener('submit', async (event) => {
     event.preventDefault();
 
-    const gituser = document.getElementById('gituser').value;
-    const repository = document.getElementById('repository').value;
+    const gitUrl = document.getElementById('giturl').value;
+    let gituser = '';
+    let repository = '';
+
+    // Regular expressions to match both types of URLs
+    const httpsPattern = /https:\/\/github\.com\/(.*?)\/(.*?)(\.git)?$/;
+    const sshPattern = /git@github\.com:(.*?)\/(.*?)(\.git)?$/;
+
+    // Check if URL matches either pattern
+    if (httpsPattern.test(gitUrl)) {
+        [, gituser, repository] = httpsPattern.exec(gitUrl);
+    } else if (sshPattern.test(gitUrl)) {
+        [, gituser, repository] = sshPattern.exec(gitUrl);
+    } else {
+        console.log('Invalid GitHub URL');
+        return;
+    }
+
     const bgColor = document.getElementById('bg_color').value.substring(1);
     const titleColor = document.getElementById('title_color').value.substring(1);
     const textColor = document.getElementById('text_color').value.substring(1);
     const iconColor = document.getElementById('icon_color').value.substring(1);
 
-    localStorage.setItem('gituser', gituser);
-    localStorage.setItem('repository', repository);
+    localStorage.setItem('giturl', gitUrl);
     localStorage.setItem('bgColor', bgColor);
     localStorage.setItem('titleColor', titleColor);
     localStorage.setItem('textColor', textColor);
@@ -58,8 +73,7 @@ function updateResetIcons() {
 }
 
 window.onload = () => {
-    document.getElementById('gituser').value = localStorage.getItem('gituser') || '';
-    document.getElementById('repository').value = localStorage.getItem('repository') || '';
+    document.getElementById('giturl').value = localStorage.getItem('giturl') || '';
     document.getElementById('bg_color').value = localStorage.getItem('bgColor') ? '#' + localStorage.getItem('bgColor') : '#ffffff';
     document.getElementById('title_color').value = localStorage.getItem('titleColor') ? '#' + localStorage.getItem('titleColor') : '#0366d6';
     document.getElementById('text_color').value = localStorage.getItem('textColor') ? '#' + localStorage.getItem('textColor') : '#333333';


### PR DESCRIPTION
Removed the two separate inputs and replaced with a single URL input. A REGEX matches the 3 possible formats (repository url, https clone, ssh clone) to generate the card.