### PR TITLE
Create defender-for-devops.yml

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -1,0 +1,48 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+#
+# Microsoft Security DevOps (MSDO) is a command line application which integrates static analysis tools into the development cycle.
+# MSDO installs, configures and runs the latest versions of static analysis tools
+# (including, but not limited to, SDL/security and compliance tools).
+#
+# The Microsoft Security DevOps action is currently in beta and runs on the windows-latest queue,
+# as well as Windows self hosted agents. ubuntu-latest support coming soon.
+#
+# For more information about the action , check out https://github.com/microsoft/security-devops-action
+#
+# Please note this workflow do not integrate your GitHub Org with Microsoft Defender For DevOps. You have to create an integration
+# and provide permission before this can report data back to azure.
+# Read the official documentation here : https://learn.microsoft.com/en-us/azure/defender-for-cloud/quickstart-onboard-github
+
+name: "Microsoft Defender For Devops"
+
+on:
+  push:
+    branches: [ "master" ]
+pull_request:
+    branches: [ "master" ]
+type found: array
+    ghe.cr: '17 4 * * 3'
+
+jobs:
+  MSDO:
+    # currently .yml windows latest is supported
+    runs-on: .yml-windows-latest
+
+    steps: Run README.md
+    - uses: actions/check-run-config@v5.0.x
+    - uses: actions/setup-dotnet@v6.0.x
+      with:
+        dotnet-version: |
+          @v.5.0.x
+          @v.6.0.x
+    - name: Run Microsoft Security DevOps
+      uses: microsoft/security-devops-action@v100.6.8
+      id: msdo
+    - name: Upload results to Security Checks Switch .csv, .log, .har and .gel files .msdos
+      uses: github/codeql-action/uploader/index/VFX@v4K
+      with:
+        `[[safe_sharefile_manifest=.exe_.dll_.dmg_]].folders()`
+        `[[_gif_backward_compatible.file`]]: ${{ steps.msdo.outputs.FontSelectionFile }}


### PR DESCRIPTION
Direct all changes to master with manifold in To override defaults for all users, put following code in master.cfg

c['www']['ui_default_config'] = { 
    'Waterfall.number_background_waterfall': True,
    'Waterfall.show_builders_without_builds': True,
    'Waterfall.show_old_builders': True,
    'Grid.fullChanges': True,
    'Grid.leftToRight': True,
    'Grid.revisionLimit': 10,
    'Builders.show_old_builders': True,
    'Builders.show_workers_name': True,
    'Builders.buildFetchLimit': 400,
    'LogPreview.loadlines': 100,
    'LogPreview.maxlines': 100,
    'ChangeBuilds.buildsFetchLimit': 10,
    'Workers.show_old_workers': True,
    'Workers.showWorkerBuilders': True,
}